### PR TITLE
Redirect external login requests

### DIFF
--- a/proxy/proxy.conf.mjs
+++ b/proxy/proxy.conf.mjs
@@ -9,6 +9,16 @@ import {deepMerge} from "./proxy-utils.mjs";
 
 const proxyRules = [
   {
+    // redirect external login requests
+    context: ["/primaws/suprimaExtLogin"],
+    target: PROXY_TARGET,
+    changeOrigin: true,
+    followRedirects: true,
+    onProxyReq(_proxyReq, req, res) {
+      res.writeHead(302, { location: PROXY_TARGET + req.url });
+    },
+  },
+  {
     context: [
       '/custom/*/assets',
       '/custom/*/assets/**',
@@ -78,3 +88,4 @@ const proxyRules = [
 
 
 export default proxyRules;
+


### PR DESCRIPTION
When working on features that require authentication, I noticed that every time I saved a change, I would get logged out following the subsequent browser refresh. The only way I've been able to prevent this behavior is to add a proxy rule that redirects external login requests directly to the Primo target (bypassing the proxy). 

I've tested with SAML, but there are several other external auth schemes that we do not use. *Please feel free to reject this PR if you think it might cause problem for others.*